### PR TITLE
fix: multiple upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,6 @@
 'use strict'
 
+var queue = require('queue')
 var path = require('path')
 var crypto = require('crypto')
 var Client = require('ssh2-sftp-client')
@@ -31,6 +32,10 @@ function SFTPStorage (opts) {
   }
 
   this.client = opts.client || new Client()
+  this.queue = queue({
+    concurrency: 1,
+    autostart: true
+  })
 }
 
 SFTPStorage.prototype._handleFile = function _handleFile (req, file, cb) {
@@ -42,15 +47,18 @@ SFTPStorage.prototype._handleFile = function _handleFile (req, file, cb) {
 
       var finalPath = path.join(destination, filename)
 
-      this.client.connect(this.sftp)
-        .then(() => this.client.put(file.stream, finalPath))
-        .then((data) => cb(null, {
-          destination: destination,
-          filename: filename,
-          path: finalPath
-        }))
-        .catch((err) => cb(err))
-        .then(() => this.client.end())
+      this.queue.push(() => {
+          return this.client.connect(this.sftp)
+            .then(() => this.client.put(file.stream, finalPath))
+            .then((data) => cb(null, {
+              destination: destination,
+              filename: filename,
+              path: finalPath
+            }))
+            .catch((err) => cb(err))
+            .then(() => this.client.end())
+        }
+      )
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "multer": "^1.4.2",
     "nyc": "^15.0.0",
     "on-finished": "^2.3.0",
+    "queue": "^6.0.1",
     "ssh2-sftp-client": "^5.0.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
Fixes #9 

Used [queue](https://www.npmjs.com/package/queue) as event queue

Autostart, concurrency option is given to event queue 
so that job function is processed as soon as it is pushed
and only one job function is processed at the time

In _handleFile, uploading code is pushed to event queue
